### PR TITLE
standalone mkinv.py should use client.openstack

### DIFF
--- a/standalone/mkinv.py
+++ b/standalone/mkinv.py
@@ -5,6 +5,9 @@ import yaml
 with open('/home/stack/ceph_client.yaml', 'r') as ceph_client_file:
     ceph_client = yaml.safe_load(ceph_client_file)
 
+for i in range(0, len(ceph_client['keys'])):
+    ceph_client['keys'][i]['name'] = 'client.' + ceph_client['keys'][i]['name']
+
 standalone_vars = {
     'tripleo_ceph_client_config_home': '/var/lib/tripleo-config/ceph',
     'tripleo_cinder_enable_rbd_backend': True,


### PR DESCRIPTION
An unfortunate inconsistency between exsiting client input methods:

ceph.client.openstack.keyring
ceph.openstack.keyring

As documented already:

https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/features/ceph_external.html#configuring-ceph-clients-for-multiple-external-ceph-rbd-services

I've updated the proposed doc too:

https://review.opendev.org/c/openstack/tripleo-docs/+/859142/3..4/deploy-guide/source/features/ceph_external.rst